### PR TITLE
PedroDiez: adding_new_codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @PedroDiez @ToshiWakayama-KDDI
+* @PedroDiez @ToshiWakayama-KDDI @bigludo7


### PR DESCRIPTION
Ludovic from Orange has kindly offered as codeowner. 
We need other codeowner to be able to work with approval of contributions of any kind.

Now we are blocked for instance in the merging of meeting minutes