### PR TITLE
PedroDiez: rename_documentation_files

### DIFF
--- a/documentation/API_documentation/Carrier Billing-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/Carrier Billing-API-Readiness-Checklist.md
@@ -1,4 +1,4 @@
-# Carrier Billing Checkout API Readiness minimum criteria checklist
+# Carrier Billing API Readiness minimum criteria checklist
 
 <br>
 

--- a/documentation/API_documentation/Carrier Billing-API-roadmap.md
+++ b/documentation/API_documentation/Carrier Billing-API-roadmap.md
@@ -1,4 +1,4 @@
-# Carrier Billing Checkout API roadmap
+# Carrier Billing API roadmap
 
 **Phase 1 Features - Initial Version**
 * Individual Payments Procedure


### PR DESCRIPTION
## PR

Rename a couple of docs to remove "word" checkout, in order to avoid misunderstanding as we have two proposals for the API Family