### PR TITLE
Meetings_Scheduling_Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Repository to describe, develop, document and test the CarrierBillingCheckOut AP
 ## Meetings
 * Meetings are held virtually
 * Schedule:
-  * Weekly, Wednesdays 16:30 - 17:30 (GMT+1)
-  * Bi-Weekly, Wednesdays 16:30 - 17:30 (GMT+1) (Starting December/22)
+  * Weekly, Wednesdays 16:00 - 17:00 (GMT+1)
+  * Bi-Weekly, Wednesdays 16:00 - 17:00 (GMT+1) (Starting 2023 TBD)
 * Meeting link: https://teams.microsoft.com/l/meetup-join/19%3ameeting_MjlhNzg3NTctYjAyYS00ZjM0LTlmZDEtYjE2NGFmNjYyZmM5%40thread.v2/0?context=%7b%22Tid%22%3a%229744600e-3e04-492e-baa1-25ec245c6f10%22%2c%22Oid%22%3a%2219764050-b5d5-4991-9f15-d10905a94c08%22%7d
 
 ## Contributorship and mailing list


### PR DESCRIPTION
## PR

Update of meetings schedule (Begin at 16:00).
Set bi-weekly meetings to be talked during 2023. First two months better to keep weekly meetings (maybe one week we can cancel on-demand basis)