### PR TITLE
release-v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,41 @@
 
 ## Table of Contents
 
+- [v0.2.1](#v0.2.1)
 - [v0.2.0](#v0.2.0)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+## v0.2.1
+
+**Fix over the first release**
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-v0.2.1/code/API_definitions/carrier_billing.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-v0.2.1/code/API_definitions/carrier_billing.yaml)
+  - OpenAPI [YAML spec file](https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-v0.2.1/code/API_definitions/carrier_billing.yaml)
+
+### Added
+
+* N/A
+
+### Changed
+
+* N/A
+
+### Fixed
+
+* Fix `operationId` name of callbacks to be unique.
+
+### Removed
+
+* N/A
+
+## New Contributors
+* N/A
+
+
+**Full Changelog**: https://github.com/camaraproject/CarrierBillingCheckOut/commits/v0.2.1
 
 ## v0.2.0
 

--- a/code/API_definitions/carrier_billing.yaml
+++ b/code/API_definitions/carrier_billing.yaml
@@ -100,7 +100,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.2.0
+  version: 0.2.1
   title: Carrier Billing
   termsOfService: http://swagger.io/terms/
   contact:
@@ -157,7 +157,7 @@ paths:
               tags:
                 - Payment Notifications
               summary: Carrier Billing payment notifications
-              operationId: paymentNotification
+              operationId: createPaymentNotification
               description: |
                 Important: This endpoint is exposed by the API client, accepting requests in the defined format.
                 The Carrier Billing server will call this endpoint whenever any carrier billing related event occurs.
@@ -339,7 +339,7 @@ paths:
               tags:
                 - Payment Notifications
               summary: Carrier Billing payment notifications
-              operationId: paymentNotification
+              operationId: preparePaymentNotification
               description: |
                 Important: This endpoint is exposed by the API client, accepting requests in the defined format.
                 The Carrier Billing server will call this endpoint whenever any carrier billing related event occurs.


### PR DESCRIPTION
#### What type of PR is this?

* correction
* subproject management


#### What this PR does / why we need it:

Generate Release v0.2.1, as a Fix of release v0.2.0

Change `operationId` names for callbacks to be unique (may generate publication and code generation topics)


#### Which issue(s) this PR fixes:

Fixes #144 


#### Special notes for reviewers:

Minor Change
