### PR TITLE
chore: meeting_minutes_readme_information

### DIFF
--- a/documentation/MeetingMinutes/README.MD
+++ b/documentation/MeetingMinutes/README.MD
@@ -1,1 +1,3 @@
-Here you can add your meeting minutes and delete this README.MD file
+## RELEVANT INFORMATION
+
+Since 3rd April WG Meeting, meeting minutes are placed in [CAMARA Carrier Billing WG Wiki Confluence site](https://wiki.camaraproject.org/display/CAM/sp-cbc+Meeting+Minutes)


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management


#### What this PR does / why we need it:

As per TSC guideline and commented in Meeting of 3rd April, meeting minutes are begin to be collected in Confluence site for CAMARA Sub-proyects. Updating README file to point to the new site
