### PR TITLE
Release 0.3.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,93 @@
-# Changelog CarrierBillingCheckOut
+# Changelog CarrierBillingCheckOut API Family
 
 ## Table of Contents
 
-- [v0.2.1](#v0.2.1)
-- [v0.2.0](#v0.2.0)
+- [r0.3.0-rc.1](#r030-rc1)
+- [v0.2.1](#v021)
+- [v0.2.0](#v020)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+The below sections record the changes for each API version in each release as follows:
+
+* for each first alpha or release-candidate API version, all changes since the release of the previous public API version
+* for subsequent alpha or release-candidate API versions, the delta with respect to the previous pre-release
+* for a public API version, the consolidated changes since the release of the previous public API version
+
+## r0.3.0-rc.1
+
+## Release Notes
+
+This first release candidate r0.3.0-rc.1 contains the definition and documentation of
+* Carrier Billing v0.3.0-rc.1
+* Carrier Billing Refund v0.1.0-rc.1
+
+The API definition(s) are based on
+* Commonalities v0.4.0
+* Identity and Consent Management v0.2.0
+
+## Carrier Billing v0.3.0-rc.1
+
+**Carrier Billing v0.3.0-rc.1 is the first release-candidate version for v0.3.0 of the Carrier Billing (Payment) API.**
+- **This version contains significant changes compared to v0.2.1, and it is not backward compatible:**
+  - Within notifications, callback concept named as `webhook` has been replaced by the terms `sink` and `sinkCredential` in accordance with the updated CAMARA Design Guidelines (Adoption of CloudEvent Subscription Model within MetaRelease Fall24 (v0.4.0))
+  - Exceptions has also been aligned with Commonalities MetaRelease-Fall24 (v0.4.0), so as some excepctions has changed their `HTTP` and/or `status` values.
+  - Version designed to work jointly with Carrier Billing Refund API
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml)
+
+### Added
+* N/A
+
+### Changed
+* Support for non-negative `amount` and `taxAmount` values in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+* Adoption of CloudEvents Subscription Model replacing `webhook` by `sink` and `sinkCredential` concepts as well as aligning callback endpoint for notifications in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+* Aligment of Exceptions with Commonalities MetaRelease Fall24 in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+* Alignment of Authorization and authentication section with I&CM MetaRelease Fall24 in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+
+### Fixed
+* Clarifications on descriptions and editorial enhancements in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+
+### Removed
+* N/A
+
+## Carrier Billing Refund v0.1.0-rc.1
+
+**Carrier Billing Refund v0.1.0-rc.1 is the first release-candidate version for v0.1.0 of the Carrier Billing Refund API.**
+- **This version defines a new API:**
+  - Initial version covering the following functionality and related endpoints:
+    - New endpoint `createRefund`, both total and partial refunds
+    - New endpoint `retrieveRefunds`
+    - New endpoint `retrieveRefund`
+    - New endpoint `retrievePaymentRemainingAmount`
+    - Support for `Instance-based (implicit) subscription` notification mode
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml)
+
+### Added
+* Added new Carrier Billing Refund API with the functionality aforementioned indicated (create a refund, query details of a given refund or a list of refunds, retrieve the amount not yet refunded of a given payment, support for implicit-based subscription) in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+* Aligned with Commonalities and I&CM MetaRelease Fall24 in https://github.com/camaraproject/CarrierBillingCheckOut/pull/152
+
+### Changed
+* N/A
+
+### Fixed
+* N/A
+
+### Removed
+* N/A
+
+## New Contributors
+* N/A
+
+
+**Full Changelog**: https://github.com/camaraproject/CarrierBillingCheckOut/compare/v0.2.1...r0.3.0-rc.1
 
 ## v0.2.1
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,29 @@ Repository to describe, develop, document and test the CarrierBilling API family
   * Bi-Weekly, Wednesdays 16:00 - 17:00 CET/CEST
 * Meeting link: [Link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_M2UzOTNhOWItMmNkNC00NDVjLWIzYjAtYzgxNDBkOGY2MjFi%40thread.v2/0?context=%7b%22Tid%22%3a%229744600e-3e04-492e-baa1-25ec245c6f10%22%2c%22Oid%22%3a%2219764050-b5d5-4991-9f15-d10905a94c08%22%7d)
 
-## Results
-* Sub Project is in progress
+## Status and released versions
+* Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
+
+* **The first Release Candidate for r0.3.0 for the Carrier Billing APIs Family is available.**
+<br>Until the release there are bug fixes to be expected. The release candidate is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* The first release candidate for r0.3.0 is available in the [release-0.3.0-rc.1 branch](https://github.com/camaraproject/CarrierBillingCheckOut/tree/release-0.3.0-rc.1), involving the following APIs:
+- API name: Carrier Billing (Payment) - API Definition r0.3.0-rc.1 with inline documentation:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/release-0.3.0-rc.1/code/API_definitions/carrier_billing.yaml)
+
+- API name: Carrier Billing Refund - API Definition r0.1.0-rc.1 with inline documentation:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/release-0.3.0-rc.1/code/API_definitions/carrier_billing_refund.yaml)
+
+* For changes between v0.3.0-rc.1 and v0.2.1 see the [CHANGELOG.md](https://github.com/camaraproject/CarrierBillingCheckOut/blob/main/CHANGELOG.md)
+
+* **The latest available and released version 0.2.1 is available within the [release-0.2.1 branch](https://github.com/camaraproject/CarrierBillingCheckOut/tree/release-v0.2.1)**
+  - API name: Carrier Billing (Payment) - API Definition v0.2.1 with inline documentation:
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-v0.2.1/code/API_definitions/carrier_billing.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/release-v0.2.1/code/API_definitions/carrier_billing.yaml)
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/release-v0.2.1/code/API_definitions/carrier_billing.yaml)
 
 ## Contributorship and mailing list
 * To subscribe / unsubscribe to the mailing list of this Sub Project and thus be / resign as Contributor please visit <https://lists.camaraproject.org/g/sp-cbc>.

--- a/code/API_definitions/carrier_billing.yaml
+++ b/code/API_definitions/carrier_billing.yaml
@@ -108,7 +108,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.3.0-wip
+  version: 0.3.0-rc.1
   title: Carrier Billing
   termsOfService: http://swagger.io/terms/
   contact:

--- a/code/API_definitions/carrier_billing_refund.yaml
+++ b/code/API_definitions/carrier_billing_refund.yaml
@@ -52,7 +52,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.1.0-wip
+  version: 0.1.0-rc.1
   title: Carrier Billing Refunds
   termsOfService: http://swagger.io/terms/
   contact:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management


#### What this PR does / why we need it:

Generation of first release-candidate for Carrier Billing APIs Family

This first release candidate r0.3.0-rc.1 contains the definition and documentation of
* Carrier Billing v0.3.0-rc.1
* Carrier Billing Refund v0.1.0-rc.1

The API definition(s) are based on
* Commonalities v0.4.0
* Identity and Consent Management v0.2.0


#### Which issue(s) this PR fixes:

Fixes #164

#### Special notes for reviewers:

N/A

#### Changelog input

```
 Carrier Billing Release 0.4.0-rc.1

```

#### Additional documentation 

N/A