### PR TITLE
Public Release r2.2 for Carrier Billing APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ The API definition(s) are based on
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Fix `CARRIER_BILLING_REFUND.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
-* Fix some Error exceptions `CARRIER_BILLING...` to `CARRIER_BILLING_REFUND...` in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix some Error exceptions `CARRIER_BILLING...` to `CARRIER_BILLING_REFUND...` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ The API definition(s) are based on
 * Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The API definition(s) are based on
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
@@ -70,6 +71,7 @@ The API definition(s) are based on
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ## Carrier Billing Refund v0.2.0
 
@@ -100,6 +102,7 @@ The API definition(s) are based on
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
@@ -109,6 +112,7 @@ The API definition(s) are based on
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ## New Contributors
 * N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The API definition(s) are based on
 * Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [r2.2](#r22)
 - [r2.1 - rc](#r21---rc)
 - [r1.3](#r13)
 - [r1.2](#r12)
@@ -16,6 +17,104 @@ The below sections record the changes for each API version in each release as fo
 * for each first alpha or release-candidate API version, all changes since the release of the previous public API version
 * for subsequent alpha or release-candidate API versions, the delta with respect to the previous pre-release
 * for a public API version, the consolidated changes since the release of the previous public API version
+
+## r2.2
+
+## Release Notes
+
+This release contains the definition and documentation of
+* Carrier Billing v0.4.0
+* Carrier Billing Refund v0.2.0
+
+The API definition(s) are based on
+* Commonalities v0.5.0
+* Identity and Consent Management v0.3.0
+
+## Carrier Billing v0.4.0
+
+**Carrier Billing v0.4.0 is the first public release version for v0.4.0 of the Carrier Billing (Payment) API.**
+- **This version contains significant changes compared to v0.3.1, and it is not backward compatible:**
+  - Error model aligment with commonalities, which implies use of normalization values (i.e. enums) for `status` and `code`
+  - Removal of `403 - INVALID_TOKEN_CONTEXT`
+  - Removal of `5XX` errors
+  - Addition of `403 - CARRIER_BILLING.INVALID_PAYMENT_CONTEXT` for GET endpoints
+  - Addition of applicable `422` traversal exceptions  
+  - Addition of `429 - TOO_MANY_REQUESTS`
+
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier_billing.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier_billing.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.2/code/API_definitions/carrier_billing.yaml)
+
+### Added
+* Added `# Identifying the phone number from the access token` section within `info.description` from Commonalities guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added `403 - CARRIER_BILLING.INVALID_PAYMENT_CONTEXT` for GET endpoints, to deal with the case where 3-legged Access Token is not valid for payment context, that is paymentId is not related to the phone number associated to the token in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added applicable `422` traversal exceptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added `429 - TOO_MANY_REQUESTS` to API endpoints in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added Gherkin Testing Linter in https://github.com/camaraproject/CarrierBillingCheckOut/pull/191.
+* Generate Tests for 429 Error in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Changed
+* Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Fixed
+* Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Removed
+* Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+
+## Carrier Billing Refund v0.2.0
+
+**Carrier Billing Refund v0.2.0 is the first public release version for v0.2.0 of the Carrier Billing Refund API.**
+- **This version contains significant changes compared to v0.1.1, and it is not backward compatible:**
+  - Error model aligment with commonalities, which implies use of normalization values (i.e. enums) for `status` and `code`
+  - Removal of `403 - INVALID_TOKEN_CONTEXT`
+  - Removal of `5XX` errors
+  - Addition of `403 - CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT` for GET endpoints
+  - Addition of applicable `422` traversal exceptions  
+  - Addition of `429 - TOO_MANY_REQUESTS`
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier_billing_refund.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier_billing_refund.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.2/code/API_definitions/carrier_billing_refund.yaml)
+
+### Added
+* Added `403 - CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT` for GET endpoints, to deal with the case where 3-legged Access Token is not valid for refund context, that is refundId is not related to the phone number associated to the token in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added applicable `422` traversal exceptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added `429 - TOO_MANY_REQUESTS` to API endpoints in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Added Gherkin Testing Linter in https://github.com/camaraproject/CarrierBillingCheckOut/pull/191.
+* Generate Tests for 429 Error in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Changed
+* Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Update API specification version and servers.url in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Fixed
+* Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+
+### Removed
+* Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+* Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
+
+## New Contributors
+* N/A
+
+
+**Full Changelog**: https://github.com/camaraproject/CarrierBillingCheckOut/compare/r1.3...r2.2
 
 ## r2.1 - rc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ The API definition(s) are based on
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ## Carrier Billing Refund v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
 
 The below sections record the changes for each API version in each release as follows:
 
-* for each first alpha or release-candidate API version, all changes since the release of the previous public API version
-* for subsequent alpha or release-candidate API versions, the delta with respect to the previous pre-release
-* for a public API version, the consolidated changes since the release of the previous public API version
+* for an alpha release, the delta with respect to the previous release
+* for the first release-candidate, all changes since the last public release
+* for subsequent release-candidate(s), only the delta to the previous release-candidate
+* for a public release, the consolidated changes since the previous public release
 
 ## r2.2
 
@@ -102,7 +103,7 @@ The API definition(s) are based on
 * Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
-* Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update Test Definitions API version in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update `sink` format to `uri` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ The API definition(s) are based on
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Removed `sinkCredential` from API responses in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Remove `Content-Last-Key` and `X-Total-Count` from `retrieveRefund` and `retrievePaymentRemainingAmount` operations as they are not applicable in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ## New Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ The API definition(s) are based on
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
-* Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `sink` format to `uri` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The API definition(s) are based on
 * Added applicable `422` traversal exceptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Added `429 - TOO_MANY_REQUESTS` to API endpoints in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Added Gherkin Testing Linter in https://github.com/camaraproject/CarrierBillingCheckOut/pull/191.
-* Generate Tests for 429 Error in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Generate Tests for 429 Error in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Changed
 * Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ The API definition(s) are based on
 * Added applicable `422` traversal exceptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Added `429 - TOO_MANY_REQUESTS` to API endpoints in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Added Gherkin Testing Linter in https://github.com/camaraproject/CarrierBillingCheckOut/pull/191.
-* Generate Tests for 429 Error in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Generate Tests for 429 Error in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Changed
 * Updated `# Authorization and authentication` section from ICM guideline in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ The API definition(s) are based on
 * Error model aligment with commonalities. Normalization values (i.e. enums) for `status` and `code`. In https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
-* Update Test Definitions API version in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update Test Definitions API version in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ The API definition(s) are based on
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
-* Remove `Content-Last-Key` and `X-Total-Count` from `retrieveRefund` and `retrievePaymentRemainingAmount` operations as they are not applicable in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Remove `Content-Last-Key` and `X-Total-Count` from `retrieveRefund` and `retrievePaymentRemainingAmount` operations as they are not applicable in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ## New Contributors
 * N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The API definition(s) are based on
 * Updated testing plan in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update API specification version and servers.url in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Update Test Definitions API version in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
-* Update `sink` format to `uri` in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `sink` format to `uri` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ The API definition(s) are based on
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `5XX` errors in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Removed `sinkCredential` from API responses in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Remove `Content-Last-Key` and `X-Total-Count` from `retrieveRefund` and `retrievePaymentRemainingAmount` operations as they are not applicable in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ## New Contributors
 * N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ The API definition(s) are based on
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
-* Fix `CARRIER_BILLING.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix `CARRIER_BILLING.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ The API definition(s) are based on
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Fix `CARRIER_BILLING.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The API definition(s) are based on
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix `CARRIER_BILLING.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
@@ -108,6 +109,8 @@ The API definition(s) are based on
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix `CARRIER_BILLING_REFUND.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix some Error exceptions `CARRIER_BILLING...` to `CARRIER_BILLING_REFUND...` in https://github.com/camaraproject/CustomerInsights/pull/206.
 
 ### Removed
 * Removed `403 - INVALID_TOKEN_CONTEXT` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ The API definition(s) are based on
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
-* Fix `CARRIER_BILLING_REFUND.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Fix `CARRIER_BILLING_REFUND.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Fix some Error exceptions `CARRIER_BILLING...` to `CARRIER_BILLING_REFUND...` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ The API definition(s) are based on
 ### Fixed
 * Updated `accessTokenExpiresUtc` description in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
 * Some clarifications on descriptions in https://github.com/camaraproject/CarrierBillingCheckOut/pull/202.
-* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CustomerInsights/pull/206.
+* Update `@{operationId}_403.01_invalid_token_permissions` test wording to be more generic in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 * Fix `CARRIER_BILLING_REFUND.INVALID_DATE_RANGE` description in https://github.com/camaraproject/CustomerInsights/pull/206.
 * Fix some Error exceptions `CARRIER_BILLING...` to `CARRIER_BILLING_REFUND...` in https://github.com/camaraproject/CarrierBillingCheckOut/pull/206.
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@
 <a href="https://github.com/camaraproject/CarrierBillingCheckOut/releases/latest" title="Latest Release"><img src="https://img.shields.io/github/release/camaraproject/CarrierBillingCheckOut?style=plastic"></a>
 
 # CarrierBillingCheckOut
-Repository to describe, develop, document and test the CarrierBilling API family
+Repository to describe, develop, document and test the CarrierBilling APIs
 
 ## Scope
 * Service APIs for “CarrierBillingCheckOut” (see APIBacklog.md)  
-* It provides the customer with the ability to: 
-  * trigger carrier billing payment request (in one or two steps) 
-  * follow up of payment processing using as Payment Method Carrier Billing, i.e.: the operator performs the billing of the goods.
-  * NOTE: The scope of this API family should be limited (at least at a first stage) to 4G and 5G.
+* It provides the API consumer with the ability to: 
+  * Trigger carrier billing payment request (in one or two steps), which is a process that allows API consumers to make purchases by charging payments against Telco Operator Billing Systems.
+    * Follow up of payment, by means of query endpoints to get information about a list of payments or a specific payment.
+  * Trigger carrier billing refund request, which is a process that allows API consumers to ask for a `total` or `partial` return of the amount associated to a previous performed payment.
+    * Follow up of refund, by means of query endpoints to get information about a list of refunds or a specific refund.
+  * NOTE: The scope of these APIs should be limited (at least at a first stage) to 4G and 5G.
 * Describe, develop, document and test the APIs (with 1-2 Telcos)  
-  * Started: October 2022
-  * Location: virtually  
+  * Started: October 2022 
 
 ## Release Information
 <!-- Use/uncomment one or multiple the following options -->

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ Repository to describe, develop, document and test the CarrierBilling API family
 <!-- For changes see [CHANGELOG.md](https://github.com/camaraproject/§repo_name§/blob/main/CHANGELOG.md) -->
 * Note: Please be aware that the project will have updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 
-* **The pre-release [r2.1 - rc](https://github.com/camaraproject/CarrierBillingCheckOut/blob/main/CHANGELOG.md#r2.1---rc) for the Carrier Billing APIs Family is available.**
-<br>This is a release candidate. Until the public release there are bug fixes to be expected. The release candidate is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* **The Release [r2.2](https://github.com/camaraproject/CarrierBillingCheckout/releases/tag/r2.2) for the Carrier Billing APIs Family is available.**
+<br>This is a public release.
 
-* The release **r2.1 - rc** is available in [r2.1](https://github.com/camaraproject/CarrierBillingCheckOut/tree/r2.1), and includes the following APIs:
-- API name: Carrier Billing (Payment) - API Definition v0.4.0-rc.1 with inline documentation:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.1/code/API_definitions/carrier-billing.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.1/code/API_definitions/carrier-billing.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.1/code/API_definitions/carrier-billing.yaml)
+* The release **r2.2** is available in [r2.2](https://github.com/camaraproject/CarrierBillingCheckOut/tree/r2.2), and includes the following APIs:
+- API name: Carrier Billing (Payment) - API Definition v0.4.0 with inline documentation:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier-billing.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier-billing.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.2/code/API_definitions/carrier-billing.yaml)
 
-- API name: Carrier Billing Refund - API Definition v0.2.0-rc.1 with inline documentation:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.1/code/API_definitions/carrier-billing-refund.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.1/code/API_definitions/carrier-billing-refund.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.1/code/API_definitions/carrier-billing-refund.yaml)
+- API name: Carrier Billing Refund - API Definition v0.2.0 with inline documentation:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier-billing-refund.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/CarrierBillingCheckOut/r2.2/code/API_definitions/carrier-billing-refund.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/CarrierBillingCheckOut/blob/r2.2/code/API_definitions/carrier-billing-refund.yaml)
 
 * Other releases of this sub project are available in [CarrierBillingCheckout Releases](https://github.com/camaraproject/CarrierBillingCheckout/releases)
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/CarrierBillingCheckout/blob/main/CHANGELOG.md)

--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -370,7 +370,7 @@ components:
           description: Reason provided to request the refund. Optionally provided by the user or the merchant.
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
@@ -439,13 +439,9 @@ components:
           description: Reason provided to request the refund. Optionally provided by the user or the merchant.
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
       discriminator:
         propertyName: type
         mapping:

--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -257,10 +257,6 @@ paths:
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
-            Content-Last-Key:
-              $ref: "#/components/headers/Content-Last-Key"
-            X-Total-Count:
-              $ref: "#/components/headers/X-Total-Count"
           content:
             application/json:
               schema:
@@ -324,10 +320,6 @@ paths:
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
-            Content-Last-Key:
-              $ref: "#/components/headers/Content-Last-Key"
-            X-Total-Count:
-              $ref: "#/components/headers/X-Total-Count"
           content:
             application/json:
               schema:

--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -923,9 +923,9 @@ components:
     GetRefundsInvalid400:
       description: |-
         Invalid input. In addition to regular INVALID_ARGUMENT scenario other scenarios may exist:
-          - Inconsistent startDate and endDate values ("code": "CARRIER_BILLING.INVALID_DATE_RANGE","message": "Client specified an invalid date range.").
+          - Inconsistent refundCreationDate.gte and refundCreationDate.lte values ("code": "CARRIER_BILLING_REFUND.INVALID_DATE_RANGE","message": "Client specified an invalid date range.").
           - Request out of range ("code": "OUT_OF_RANGE","message": "Client specified an invalid range.").
-          - Too many matching records found ("code": "CARRIER_BILLING.TOO_MANY_MATCHING_RECORDS","message": "Too many matching records found. Specify additional/suitable criteria to limit the number of records.").
+          - Too many matching records found ("code": "CARRIER_BILLING_REFUND.TOO_MANY_MATCHING_RECORDS","message": "Too many matching records found. Specify additional/suitable criteria to limit the number of records.").
       headers:
         x-correlator:
           $ref: "#/components/headers/x-correlator"
@@ -943,8 +943,8 @@ components:
                     enum:
                       - INVALID_ARGUMENT
                       - OUT_OF_RANGE
-                      - CARRIER_BILLING.INVALID_DATE_RANGE
-                      - CARRIER_BILLING.TOO_MANY_MATCHING_RECORDS
+                      - CARRIER_BILLING_REFUND.INVALID_DATE_RANGE
+                      - CARRIER_BILLING_REFUND.TOO_MANY_MATCHING_RECORDS
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               summary: Generic Invalid Argument
@@ -955,10 +955,10 @@ components:
                 message: Client specified an invalid argument, request body or query param.
             GENERIC_400_INVALID_DATE_RANGE:
               summary: Generic Invalid Date Range
-              description: Inconsistent startDate and endDate values
+              description: Inconsistent refundCreationDate.gte and refundCreationDate.lte values
               value:
                 status: 400
-                code: CARRIER_BILLING.INVALID_DATE_RANGE
+                code: CARRIER_BILLING_REFUND.INVALID_DATE_RANGE
                 message: "Client specified an invalid date range."
             GENERIC_400_OUT_OF_RANGE:
               summary: Generic Out Of Range
@@ -972,7 +972,7 @@ components:
               description: Too many matching records found
               value:
                 status: 400
-                code: CARRIER_BILLING.TOO_MANY_MATCHING_RECORDS
+                code: CARRIER_BILLING_REFUND.TOO_MANY_MATCHING_RECORDS
                 message: "Too many matching records found. Specify additional/suitable criteria to limit the number of records."
     RefundInvalid400:
       description: |-
@@ -1397,7 +1397,7 @@ components:
         format: date-time
         type: string
     Order:
-      description: Used to return the sorted results in descending (default) or ascending order, based on `paymentCreationDate` property
+      description: Used to return the sorted results in descending (default) or ascending order, based on `refundCreationDate` property
       in: query
       name: order
       required: false

--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -63,10 +63,10 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+  x-camara-commonalities: 0.5
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/CarrierBillingCheckOut
-x-camara-commonalities: 0.5
 servers:
   - url: "{apiRoot}/carrier-billing-refund/v0.2"
     variables:

--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -51,14 +51,14 @@ info:
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the provider of the application consuming the API and the operator's API exposure platform, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.2.0-rc.1
+  version: 0.2.0
   title: Carrier Billing Refunds
   license:
     name: Apache 2.0
@@ -68,7 +68,7 @@ externalDocs:
   url: https://github.com/camaraproject/CarrierBillingCheckOut
 x-camara-commonalities: 0.5
 servers:
-  - url: "{apiRoot}/carrier-billing-refund/v0.2rc1"
+  - url: "{apiRoot}/carrier-billing-refund/v0.2"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -26,7 +26,7 @@ info:
 
     This API allows to third party clients to request the payment of a (set of) digital good(s)/service(s), as well as to retrieve information about a specific payment or a list of payments.
 
-    In the scope of **version v0.3, only one-off payments are covered**. Recurrent payments (a.k.a. payment subscriptions) are not covered so far.
+    In the scope of **version v0.4, only one-off payments are covered**. Recurrent payments (a.k.a. payment subscriptions) are not covered so far.
 
     The API provides several endpoints/operations:
     - An endpoint to request a 1-STEP Payment, named `createPayment`.
@@ -133,10 +133,10 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+  x-camara-commonalities: 0.5
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/CarrierBillingCheckOut
-x-camara-commonalities: 0.5
 servers:
   - url: "{apiRoot}/carrier-billing/v0.4"
     variables:

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -599,7 +599,7 @@ components:
           $ref: "#/components/schemas/AmountTransactionInput"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
@@ -634,13 +634,9 @@ components:
           description: Date time when the payment is effectively performed. This is a business information. It must follow RFC 3339 and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
     PaymentArray:
       description: A list of payment(s)
       type: array
@@ -675,13 +671,9 @@ components:
           description: Date time when the payment is effectively performed. This is a business information. It must follow RFC 3339 and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
     SinkCredential:
       type: object
       properties:
@@ -912,13 +904,9 @@ components:
             - description: Information to perform otp validation. Only needed when business case requires it. Sending of OTP is outside the scope of this specification.
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
     BodyAmountReservationTransactionForReserveInput:
       required:
         - amountTransaction
@@ -928,7 +916,7 @@ components:
           $ref: "#/components/schemas/AmountReservationTransactionForReserveInput"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered, using the HTTP protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -107,7 +107,7 @@ info:
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the provider of the application consuming the API and the operator's API exposure platform, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 
@@ -128,7 +128,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.4.0-rc.1
+  version: 0.4.0
   title: Carrier Billing
   license:
     name: Apache 2.0
@@ -138,7 +138,7 @@ externalDocs:
   url: https://github.com/camaraproject/CarrierBillingCheckOut
 x-camara-commonalities: 0.5
 servers:
-  - url: "{apiRoot}/carrier-billing/v0.4rc1"
+  - url: "{apiRoot}/carrier-billing/v0.4"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -1372,7 +1372,7 @@ components:
     GetPaymentsInvalid400:
       description: |-
         Invalid input. In addition to regular INVALID_ARGUMENT scenario other scenarios may exist:
-          - Inconsistent startDate and endDate values ("code": "CARRIER_BILLING.INVALID_DATE_RANGE","message": "Client specified an invalid date range").
+          - Inconsistent paymentCreationDate.gte and paymentCreationDate.lte values ("code": "CARRIER_BILLING.INVALID_DATE_RANGE","message": "Client specified an invalid date range").
           - Request out of range ("code": "OUT_OF_RANGE","message": "Client specified an invalid range").
           - Too many matching records found ("code": "CARRIER_BILLING.TOO_MANY_MATCHING_RECORDS","message": "Too many matching records found. Specify additional/suitable criteria to limit the number of records.").
       headers:
@@ -1404,7 +1404,7 @@ components:
                 message: Client specified an invalid argument, request body or query param.
             GENERIC_400_INVALID_DATE_RANGE:
               summary: Generic Invalid Date Range
-              description: Inconsistent startDate and endDate values
+              description: Inconsistent paymentCreationDate.gte and paymentCreationDate.lte values
               value:
                 status: 400
                 code: CARRIER_BILLING.INVALID_DATE_RANGE

--- a/code/Test_definitions/carrier-billing-cancelPayment.feature
+++ b/code/Test_definitions/carrier-billing-cancelPayment.feature
@@ -7,7 +7,7 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation cancelPayment
   # Testing assets:
   # * A phone number eligible for payment (no restrictions for it to be used to perform a payment)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0
 
   Background: Common cancelPayment setup
     Given the resource "/carrier-billing/v0.4/payments/{paymentId}/cancel"
@@ -119,9 +119,9 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation cancelPayment
 
   @cancel_payment_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing:payments:write scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing:payments:write scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -194,6 +194,21 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation cancelPayment
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @cancel_payment_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-confirmPayment.feature
+++ b/code/Test_definitions/carrier-billing-confirmPayment.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation confirmPayment
   # * A phone number eligible for payment (no restrictions for it to be used to perform a payment)
   # * A phone number not-eligible for payment (payment is denied for it due to business conditions)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0
 
   Background: Common confirmPayment setup
     Given the resource "/carrier-billing/v0.4/payments/{paymentId}/confirm"
@@ -120,9 +120,9 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation confirmPayment
 
   @confirm_payment_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing:payments:write scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing:payments:confirm scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -206,6 +206,21 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation confirmPayment
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @confirm_payment_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-createPayment.feature
+++ b/code/Test_definitions/carrier-billing-createPayment.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation createPayment
   # * A phone number eligible for payment (no restrictions for it to be used to perform a payment)
   # * A phone number not-eligible for payment (payment is denied for it due to business conditions)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0
 
   Background: Common createPayment setup
     Given the resource "/carrier-billing/v0.4/payments"
@@ -321,9 +321,9 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation createPayment
 
   @create_payment_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing:payments:create scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing:payments:create scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -421,6 +421,21 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation createPayment
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @create_payment_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-preparePayment.feature
+++ b/code/Test_definitions/carrier-billing-preparePayment.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation preparePayment
   # * A phone number eligible for payment (no restrictions for it to be used to perform a payment)
   # * A phone number not-eligible for payment (payment is denied for it due to business conditions)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0
 
   Background: Common preparePayment setup
     Given the resource "/carrier-billing/v0.4/payments/prepare"
@@ -334,9 +334,9 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation preparePayment
 
   @prepare_payment_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing:payments:create scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing:payments:create scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -434,6 +434,21 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation preparePayment
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @prepare_payment_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-refund-createRefund.feature
+++ b/code/Test_definitions/carrier-billing-refund-createRefund.feature
@@ -374,7 +374,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation createRefund
     And the header "Authorization" is set to a valid access token
     When the HTTP "POST" request is sent
     Then the response status code is 404
-    And the response property "$.status" is 409
+    And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
@@ -426,7 +426,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation createRefund
     And the path parameter "paymentId" is set to a valid value of a payment whose "paymentStatus" != "succeeded"
     And the header "Authorization" is set to a valid access token
     When the HTTP "POST" request is sent
-    Then the response status code is 409
+    Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "CARRIER_BILLING_REFUND.INVALID_PAYMENT_STATUS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/carrier-billing-refund-createRefund.feature
+++ b/code/Test_definitions/carrier-billing-refund-createRefund.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation createRefund
   # * A phone number eligible for payment & refund (no restrictions for it to be used to perform a payment or refund)
   # * A phone number not-eligible for refund (refund is denied for it due to business conditions)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0
 
   Background: Common createRefund setup
     Given the resource "/carrier-billing-refund/v0.2/refunds"
@@ -323,9 +323,9 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation createRefund
 
   @create_refunds_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing-refund:refunds:create scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing-refund:refunds:create scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -453,6 +453,21 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation createRefund
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "CARRIER_BILLING_REFUND.REFUND_DETAILS_MISMATCH"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @create_refunds_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-refund-retrievePaymentRemainingAmount.feature
+++ b/code/Test_definitions/carrier-billing-refund-retrievePaymentRemainingAmount.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrievePaymentRema
   # * A phone number eligible for payment & refund
   # * Several payments refunds performed in different situations (total and partial)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0
 
   Background: Common retrievePayment setup
     Given the resource "/carrier-billing-refund/v0.2/payments/{paymentId}/refunds/remaining-amount"
@@ -151,8 +151,8 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrievePaymentRema
 
   @retrieve_payment_remaining_amount_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing-refund:refunds:read scope
-    Given header "Authorization" is set to a valid access token emitted without carrier-billing-refund:refunds:read scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
+    Given header "Authorization" is set to an access token without the required scope
     And the path parameter "paymentId" is set to a valid value
     When the HTTP "GET" request is sent
     Then the response status code is 403
@@ -177,10 +177,24 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrievePaymentRema
   Scenario: Payment not found
     Given the path parameter "paymentId" is set to non-existing value in the environment
     And the header "Authorization" is set to a valid access token
-    When the HTTP "POST" request is sent
+    When the HTTP "GET" request is sent
     Then the response status code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @retrieve_payment_remaining_amount_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given the path parameter "paymentId" is set to a valid value in the environment
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "GET" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-refund-retrieveRefund.feature
+++ b/code/Test_definitions/carrier-billing-refund-retrieveRefund.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefund
   # * A phone number eligible for payment & refund
   # * Several payments and refunds performed in the environment (at least 10 for each of them)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0
 
   Background: Common retrieveRefund setup
     Given the resource "/carrier-billing-refund/v0.2/payments/{paymentId}/refunds/{refundId}"
@@ -78,8 +78,8 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefund
 
   @retrieve_refund_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing-refund:refunds:read scope
-    Given header "Authorization" is set to a valid access token emitted without carrier-billing-refund:refunds:read scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
+    Given header "Authorization" is set to an access token without the required scope
     And the path parameter "paymentId" is set to a valid value
     When the HTTP "GET" request is sent
     Then the response status code is 403
@@ -107,7 +107,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefund
     Given the path parameter "paymentId" is set to a non-existing value in the environment
     And the path parameter "refundId" is set to a valid value in the environment
     And the header "Authorization" is set to a valid access token
-    When the HTTP "POST" request is sent
+    When the HTTP "GET" request is sent
     Then the response status code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
@@ -118,10 +118,25 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefund
     Given the path parameter "paymentId" is set to a valid value in the environment
     And the path parameter "refundId" is set to a non-existing value in the environment
     And the header "Authorization" is set to a valid access token
-    When the HTTP "POST" request is sent
+    When the HTTP "GET" request is sent
     Then the response status code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @retrieve_refund_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given the path parameter "paymentId" is set to a valid value in the environment
+    And the path parameter "refundId" is set to a valid value in the environment
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "GET" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-refund-retrieveRefunds.feature
+++ b/code/Test_definitions/carrier-billing-refund-retrieveRefunds.feature
@@ -8,7 +8,7 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefunds
   # * A phone number eligible for payment & refund
   # * Several payments and refunds performed in the environment (at least 10 for each of them)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing-refund.yaml, version 0.2.0
 
   Background: Common retrievePayment setup
     Given the resource "/carrier-billing-refund/v0.2/payments/{paymentId}/refunds"
@@ -276,8 +276,8 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefunds
 
   @retrieve_refunds_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing-refund:refunds:read scope
-    Given header "Authorization" is set to a valid access token emitted without carrier-billing-refund:refunds:read scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
+    Given header "Authorization" is set to an access token without the required scope
     When the HTTP "GET" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -292,6 +292,21 @@ Feature: CAMARA Carrier Billing Refund API, v0.2 - Operation retrieveRefunds
     Then the response status code is 403
     And the response property "$.status" is 403
     And the response property "$.code" is "CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @retrieve_refunds_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given the path parameter "paymentId" is set to a valid value in the environment
+    And the path parameter "refundId" is set to a valid value in the environment
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "GET" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/code/Test_definitions/carrier-billing-validatePayment.feature
+++ b/code/Test_definitions/carrier-billing-validatePayment.feature
@@ -7,7 +7,7 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation validatePayment
   # Testing assets:
   # * N/A (so far)
   #
-  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0-rc.1
+  # References to OAS spec schemas refer to schemas specifies in carrier-billing.yaml, version 0.4.0
 
   Background: Common validatePayment setup
     Given the resource "/carrier-billing/v0.4/payments/{paymentId}/validate"
@@ -140,13 +140,28 @@ Feature: CAMARA Carrier Billing API, v0.4 - Operation validatePayment
 
   @validate_payment_403.01_invalid_token_permissions
   Scenario: Inconsistent access token permissions
-    # To test this, an access token has to be obtained without carrier-billing:payments:write scope
+    # To test this scenario, it will be necessary to obtain a token without the required scope
     Given the request body is set to a valid request body
-    And the header "Authorization" is set to a valid access token emitted without carrier-billing:payments:write scope
+    And the header "Authorization" is set to an access token without the required scope
     When the HTTP "POST" request is sent
     Then the response status code is 403
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  # Error 429 scenarios
+
+  @validate_payment_429.01_Too_Many_Requests
+  #To test this scenario environment has to be configured to reject requests reaching the threshold limit settled. N is a value defined by the Telco Operator
+  Scenario: Request is rejected due to threshold policy
+    Given that the environment is configured with a threshold policy of N transactions per second
+    And the request body is set to a valid request body
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the "POST" request is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text
 
   ##############################

--- a/documentation/API_documentation/carrier-billing-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/carrier-billing-API-Readiness-Checklist.md
@@ -1,12 +1,12 @@
 # API Readiness Checklist
 
-Checklist for Carrier Billing v0.4.0-rc.1 in r2.1
+Checklist for Carrier Billing v0.4.0 in r2.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [link](/code/API_definitions/carrier-billing.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r2.2](https://github.com/camaraproject/Commonalities/releases/tag/r2.2) |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r2.1](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r2.1) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r2.3](https://github.com/camaraproject/Commonalities/releases/tag/r2.3) |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r2.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r2.3) |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | [link](/code/API_definitions/carrier-billing.yaml) |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y   | [link](/documentation/API_documentation/Carrier Billing User Story.md) |

--- a/documentation/API_documentation/carrier-billing-refund-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/carrier-billing-refund-API-Readiness-Checklist.md
@@ -1,12 +1,12 @@
 # API Readiness Checklist
 
-Checklist for Carrier Billing Refund v0.2.0-rc.1 in r2.1
+Checklist for Carrier Billing Refund v0.2.0 in r2.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [link](/code/API_definitions/carrier_billing_refund.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r2.2](https://github.com/camaraproject/Commonalities/releases/tag/r2.2) |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r2.1](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r2.1) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r2.3](https://github.com/camaraproject/Commonalities/releases/tag/r2.3) |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r2.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r2.3) |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | [link](/code/API_definitions/carrier-billing-refund.yaml) |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y   | [link](/documentation/API_documentation/Carrier Billing Refund User Story.md) |


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management
* tests


#### What this PR does / why we need it:

Public Release r2.2 for Carrier Billing APIs:
- Carrier Billing v0.4.0
- Carrier Billing Refund v0.2.0


#### Which issue(s) this PR fixes:

Fixes #194
Fixes #199 
Fixes #203 
Fixes #204

#### Special notes for reviewers:

Updated API ReadinessChecklist
Updated API spec (version and servers.url). 
> Align AuthN && AuthZ text with I&CM r2.3
> Updates in sink format and remove sinkCredential from responses
> Remove `Content-Last-Key` and `X-Total-Count` from `retrieveRefund` and `retrievePaymentRemainingAmount` operations as they are not applicable

Updated Test Definitions (403 PERMISSION_DENIED wording and adding 429 TOO_MANY_REQUESTS)
Updated Changelog.md
Updated Readme.md

#### Changelog input

```
Public Release r2.2 for Carrier Billing APIs:
- Carrier Billing v0.4.0
- Carrier Billing Refund v0.2.0

```

#### Additional documentation 

N/A