### PR TITLE
Set API Specifications to wip after Metarelease Spring25

### DIFF
--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -58,7 +58,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.2.0
+  version: wip
   title: Carrier Billing Refunds
   license:
     name: Apache 2.0
@@ -68,7 +68,7 @@ externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/CarrierBillingCheckOut
 servers:
-  - url: "{apiRoot}/carrier-billing-refund/v0.2"
+  - url: "{apiRoot}/carrier-billing-refund/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -128,7 +128,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  version: 0.4.0
+  version: wip
   title: Carrier Billing
   license:
     name: Apache 2.0
@@ -138,7 +138,7 @@ externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/CarrierBillingCheckOut
 servers:
-  - url: "{apiRoot}/carrier-billing/v0.4"
+  - url: "{apiRoot}/carrier-billing/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management


#### What this PR does / why we need it:

After Release generation set APIs specification tp wip


#### Which issue(s) this PR fixes:

Fixes #209 

#### Special notes for reviewers:

N/A

#### Changelog input

N/A

#### Additional documentation 

N/A