### PR TITLE
Add Error 404 Identifier Not Found - Fall25

### DIFF
--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -1902,7 +1902,7 @@ components:
                 code: IDENTIFIER_NOT_FOUND
                 message: phoneNumber not found.
     Identifier2StepNotFound404:
-      description: |- 
+      description: |-
         Resource Not Found.
         In addition to regular NOT_FOUND scenario other scenarios may exist:
           - Phone Number not found ("code": "IDENTIFIER_NOT_FOUND","message": "phoneNumber not found.").

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -225,6 +225,8 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/PaymentPermissionDenied403"
+        "404":
+          $ref: "#/components/responses/IdentifierNotFound404"
         "409":
           $ref: "#/components/responses/Generic409"
         "422":
@@ -395,6 +397,8 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/PaymentPermissionDenied403"
+        "404":
+          $ref: "#/components/responses/IdentifierNotFound404"
         "409":
           description: Conflict
           headers:
@@ -462,6 +466,8 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
         "409":
           description: Conflict
           headers:
@@ -528,7 +534,7 @@ paths:
         "403":
           $ref: "#/components/responses/PaymentConfirmPermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/Identifier2StepNotFound404"
         "409":
           $ref: "#/components/responses/PaymentConfirmConflict409"
         "422":
@@ -573,7 +579,7 @@ paths:
         "403":
           $ref: "#/components/responses/PaymentCancelPermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/Identifier2StepNotFound404"
         "409":
           $ref: "#/components/responses/PaymentCancelConflict409"
         "422":
@@ -1870,6 +1876,66 @@ components:
                 status: 404
                 code: NOT_FOUND
                 message: The specified resource is not found.
+    IdentifierNotFound404:
+      description: Phone Number Not Found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device. In this API it refers to a phoneNumber.
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: phoneNumber not found.
+    Identifier2StepNotFound404:
+      description: |- 
+        Resource Not Found.
+        In addition to regular NOT_FOUND scenario other scenarios may exist:
+          - Phone Number not found ("code": "IDENTIFIER_NOT_FOUND","message": "phoneNumber not found.").
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device. In this API it refers to a phoneNumber.
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: phoneNumber not found.
     Generic409:
       description: Conflict
       headers:


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This PR deals with the point of considering CAMARA exception 404 - IDENTIFIER_NOT_FOUND for the following endpoints:

CARRIER BILLING API

- createPayment
- preparePayment
- confirmPayment
- cancelPayment

They apply to 2-legged scenario, when input phoneNumber is not found

Also, taking advantage of this PR Exception 404 - NOT_FOUND is added to validatePayment endpoint (request a payment validation in 2-STEP for a payment that does not exist - applicable to both 2&3-legged scnearios)

#### Which issue(s) this PR fixes:

Fixes #214 

#### Special notes for reviewers:



#### Changelog input

```
Add exception 404 - IDENTIFIER_NOT_FOUND in Carrier Billing API (createPayment, preparePayment, confirmPayment, cancelPayment)

Add exception 404 - NOT_FOUND in Carrier Billing API (validatePayment)
```

#### Additional documentation 

N/A
