### PR TITLE
Align 404 NOT_FOUND SCOPE

### DIFF
--- a/code/API_definitions/carrier-billing-refund.yaml
+++ b/code/API_definitions/carrier-billing-refund.yaml
@@ -219,7 +219,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/RefundReadPermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
@@ -264,7 +264,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/RefundReadPermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
@@ -327,7 +327,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/RefundReadPermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
@@ -1102,7 +1102,6 @@ components:
       description: |-
         Client does not have sufficient permission.
         In addition to regular PERMISSION_DENIED scenario other scenarios may exist:
-          - Access Token is not valid for refund context (3-legged scenario) ("code": "CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT","message": "Invalid Access Token for refund context.").
           - Refund denied by business ("code": "CARRIER_BILLING_REFUND.REFUND_DENIED","message": "Refund denied by business.").
           - Payment not eligible for Refund (e.g. Payment conditions agreed do not allow refund) ("code": "CARRIER_BILLING_REFUND.PAYMENT_NOT_ELIGIBLE_FOR_REFUND","message": "Payment not eligible for refund.").
       headers:
@@ -1121,7 +1120,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT
                       - CARRIER_BILLING_REFUND.REFUND_DENIED
                       - CARRIER_BILLING_REFUND.PAYMENT_NOT_ELIGIBLE_FOR_REFUND
           examples:
@@ -1131,13 +1129,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_REFUND_CONTEXT:
-              summary: Invalid refund context
-              description: Access Token is not valid for refund context
-              value:
-                status: 403
-                code: CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT
-                message: "Invalid Access Token for refund context."
             GENERIC_403_REFUND_DENIED:
               summary: Generic Refund Denied
               description: Refund denied by business
@@ -1152,42 +1143,6 @@ components:
                 status: 403
                 code: CARRIER_BILLING_REFUND.PAYMENT_NOT_ELIGIBLE_FOR_REFUND
                 message: "Payment not eligible for refund."
-    RefundReadPermissionDenied403:
-      description: |-
-        Client does not have sufficient permission.
-        In addition to regular PERMISSION_DENIED scenario other scenarios may exist:
-          - Access Token is not valid for refund context (3-legged scenario) ("code": "CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT","message": "Invalid Access Token for refund context.").
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 403
-                  code:
-                    enum:
-                      - PERMISSION_DENIED
-                      - CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT
-          examples:
-            GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_REFUND_CONTEXT:
-              summary: Invalid refund context
-              description: Access Token is not valid for refund context
-              value:
-                status: 403
-                code: CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT
-                message: "Invalid Access Token for refund context."
     Generic404:
       description: Resource Not Found
       headers:

--- a/code/API_definitions/carrier-billing.yaml
+++ b/code/API_definitions/carrier-billing.yaml
@@ -279,7 +279,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/PaymentReadPermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "429":
           $ref: "#/components/responses/Generic429"
   /payments/{paymentId}:
@@ -316,7 +316,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/PaymentReadPermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
@@ -1808,42 +1808,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-    PaymentReadPermissionDenied403:
-      description: |-
-        Client does not have sufficient permission.
-        In addition to regular PERMISSION_DENIED scenario other scenarios may exist:
-          - Access Token is not valid for payment context (3-legged scenario) ("code": "CARRIER_BILLING.INVALID_PAYMENT_CONTEXT","message": "Invalid Access Token for payment context.").
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 403
-                  code:
-                    enum:
-                      - PERMISSION_DENIED
-                      - CARRIER_BILLING.INVALID_PAYMENT_CONTEXT
-          examples:
-            GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_PAYMENT_CONTEXT:
-              summary: Invalid payment context
-              description: Access Token is not valid for payment context
-              value:
-                status: 403
-                code: CARRIER_BILLING.INVALID_PAYMENT_CONTEXT
-                message: "Invalid Access Token for payment context."
     Generic404:
       description: Resource Not Found
       headers:


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

This PR aims to simplify the error logic for cases where a "paymentId" or "refundId" does not exist in the context of the request:
- 3-legged scenario: When Access Token is issued for a given user phone number, information would be returned in case the paymentId/refundId is associated to that user phone number and API client
- 2-legged scenario: When Access Token is not associated to a user phone number, the information is returned in case the API client managed that payment/refund.

Therefore it proposes to remove exceptions:
- CARRIER_BILLING.INVALID_PAYMENT_CONTEXT
- CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT

And align behaviour regardless the AuthZ mode (2-legged/3-legged)


#### Which issue(s) this PR fixes:

Fixes #216 

#### Special notes for reviewers:

Gherkin part to be covered under:
- carrier-billing: #225
- carrier-billing-refund: #221  

#### Changelog input

```
 Remove 403 CARRIER_BILLING.INVALID_PAYMENT_CONTEXT and CARRIER_BILLING_REFUND.INVALID_REFUND_CONTEXT exceptions

```

#### Additional documentation 

N/A
